### PR TITLE
Include links to the extension in about.md

### DIFF
--- a/about.md
+++ b/about.md
@@ -13,6 +13,9 @@ Another common example are Amazon URLs. If you search for a product on Amazon yo
 Indeed most of the above URL is tracking code. Once ClearURLs has cleaned the address, it will look like this:
 https://www.amazon.com/dp/exampleProduct
 
+### Get the extension
+
+[<img src="https://blog.mozilla.org/addons/files/2020/04/get-the-addon-fx-apr-2020.svg" alt="for Firefox" height="60px">](https://addons.mozilla.org/firefox/addon/clearurls/) [<img src="https://gitlab.com/KevinRoebert/ClearUrls/-/raw/master/promotion/MEA-button.png" alt="for Edge" height="60px">](https://microsoftedge.microsoft.com/addons/detail/mdkdmaickkfdekbjdoojfalpbkgaddei) [<img src="https://developer.chrome.com/webstore/images/ChromeWebStore_BadgeWBorder_v2_206x58.png" alt="for Chrome" height="60px">](https://chrome.google.com/webstore/detail/clearurls/lckanjgmijmafbedllaakclkaicjfmnk)
 
 ### Why use this extension as opposed to similar ones?
 


### PR DESCRIPTION
I couldn't find a link to download this extension on it's homepage! So I had to head to github to find it. It seems there should be a link on maybe the main page, and/or the about.md page.